### PR TITLE
ci: use large resource_class for deploy to fix gradle OOM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,8 +54,10 @@ jobs:
     working_directory: ~/droidFlyer
     docker:
       - image: cimg/android:2026.02.1
+    resource_class: large
     environment:
-      JVM_OPTS: -Xmx3200m
+      JVM_OPTS: -Xmx6g
+      GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2
     steps:
       - checkout
       - *restore_cache

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -159,7 +159,7 @@ task jacoco(type: JacocoReport, dependsOn: "testDebugUnitTest") {
         )
     }
     sourceDirectories.from files('src/main/kotlin')
-    executionData.from files('build/jacoco/testDebugUnitTest.exec')
+    executionData.from files('build/outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec')
 }
 
 static decodeFileFromBase64Env(String name, String fileName, String ext) {


### PR DESCRIPTION
## Summary
- Bump CircleCI \`resource_class\` to \`large\` (8 GB) for the \`deploy\` job only.
- Raise \`JVM_OPTS\` to \`-Xmx6g\` and disable the long-running gradle daemon + cap \`workers.max\` to 2 so kapt/kotlin daemons don't fan out.
- Fix \`jacoco.executionData\` path: newer AGP writes the unit-test exec file to \`build/outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec\`, so the legacy \`build/jacoco/...\` path silently SKIPped the report.

## Why
The \`deploy\` job's \`Publish APK\` was killing the Gradle daemon with **"Gradle build daemon disappeared unexpectedly"** — \`compileReleaseKotlin\` + Gradle daemon + Kotlin daemon together blow past the 4 GB ceiling on the \`medium\` resource_class. Build/test runs on the same image but only \`compileReleaseKotlin\` (with proguard prep) is heavy enough to OOM, so leaving build/test on \`medium\` keeps credit usage down.

## Test plan
- [ ] CircleCI \`build\` and \`test\` still green on master after merge
- [ ] CircleCI \`deploy\` job no longer OOMs on \`Publish APK\`
- [x] \`./gradlew clean jacoco\` produces \`app/build/reports/jacoco/jacoco/jacoco.xml\` locally (path fix verified)

Closes unhappychoice/oss-issue-opener#118

🤖 Generated with [Claude Code](https://claude.com/claude-code)