### PR TITLE
fix(build): bump minSdk from 21 to 23

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,7 +46,7 @@ android {
     }
     defaultConfig {
         applicationId "com.unhappychoice.droidflyer"
-        minSdk 21
+        minSdk 23
         targetSdk 35
         versionCode System.getenv("CIRCLE_BUILD_NUM") as Integer ?: 1
         versionName "2.0.1"


### PR DESCRIPTION
## Summary

CI has been failing because `com.google.android.material:material:1.14.0` requires `minSdkVersion >= 23`, but this project declared `minSdk 21`. The manifest merger rejects the configuration:

```
uses-sdk:minSdkVersion 21 cannot be smaller than version 23 declared in library [com.google.android.material:material:1.14.0]
```

Raising `minSdk` to 23 (Android 6.0) restores the build. Android 5.x has long since dropped below the supported install base for this app.

Closes #180 (see oss-issue-opener tracker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)