### PR TITLE
fix(build): apply kotlin-android plugin 2.4.0 explicitly

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
     id 'com.github.triplet.play' version '4.0.0'
     id 'jacoco'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'com.android.application'
-    id 'org.jetbrains.kotlin.android'
     id 'com.github.triplet.play' version '4.0.0'
     id 'jacoco'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@
 
 plugins {
     id 'com.android.application' apply false
+    id 'org.jetbrains.kotlin.android' version '2.4.0' apply false
 }
 
 task clean(type: Delete) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-plugins {
-    id 'com.android.application' apply false
-}
-
 buildscript {
     dependencies {
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.4.0'
     }
+}
+
+plugins {
+    id 'com.android.application' apply false
 }
 
 task clean(type: Delete) {

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,12 @@
 
 plugins {
     id 'com.android.application' apply false
-    id 'org.jetbrains.kotlin.android' version '2.4.0' apply false
+}
+
+buildscript {
+    dependencies {
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.4.0'
+    }
 }
 
 task clean(type: Delete) {


### PR DESCRIPTION
## Summary
- AGP ships with the Kotlin compiler at 2.2.0
- After `kotlin-reflect` / `kotlin-stdlib` were bumped to 2.4.0, the compiler can no longer read the runtime metadata: `Module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 2.4.0, expected version is 2.2.0`
- Apply the Kotlin Android plugin explicitly at 2.4.0 to match

Closes unhappychoice/oss-issue-opener#223

## Test plan
- [ ] CircleCI `build` job passes