### PR TITLE
chore(android): bump compileSdk and targetSdk to 36

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 android {
-    compileSdk 35
+    compileSdk 36
     namespace 'com.unhappychoice.droidflyer'
 
     compileOptions {
@@ -47,7 +47,7 @@ android {
     defaultConfig {
         applicationId "com.unhappychoice.droidflyer"
         minSdk 23
-        targetSdk 35
+        targetSdk 36
         versionCode System.getenv("CIRCLE_BUILD_NUM") as Integer ?: 1
         versionName "2.0.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
## Summary
- CircleCI build started failing with `okhttp-android` 5.4.0 requiring `compileSdk >= 36`:
  > Dependency 'com.squareup.okhttp3:okhttp-android:5.4.0' requires libraries and applications that depend on it to compile against version 36 or later of the Android APIs. :app is currently compiled against android-35.
- Bump `compileSdk` and `targetSdk` from 35 → 36.

## Test plan
- [ ] CircleCI `build` job passes (compiles & runs unit tests)

Refs: unhappychoice/oss-issue-opener#241